### PR TITLE
refactor(core): Repository를 Ticker 도메인으로, xlsx 저장은 별도 어댑터로 분리

### DIFF
--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Iterable
+
+from src.core.schema import Ticker
 
 
 class ILogger(ABC):
@@ -24,8 +27,13 @@ class ITickerRepository(ABC):
     @abstractmethod
     def reset_schema(self) -> None: ...
     @abstractmethod
-    def bulk_insert_from_xlsx_dir(self, data_dir: Path, filenames: list[str]) -> int: ...
+    def insert_many(self, tickers: Iterable[Ticker]) -> int: ...
     @abstractmethod
     def group_summary(self) -> list[tuple]: ...
     @abstractmethod
     def sample(self, limit: int = 5) -> list[tuple]: ...
+
+
+class IArtifactWriter(ABC):
+    @abstractmethod
+    def write(self, slug: str, tickers: Iterable[Ticker]) -> Path: ...

--- a/src/core/logic/base.py
+++ b/src/core/logic/base.py
@@ -1,15 +1,17 @@
 """마스터 파일 다운로더의 추상 베이스 (템플릿 메서드 패턴).
 
-run() 의 4단계 흐름은 모든 거래소가 공유한다:
+run() 의 흐름은 모든 거래소가 공유한다:
     1. URL 에서 zip 다운로드
     2. 압축해제 후 raw DataFrame 생성
        - 사전정의 컬럼명 검증 (방어 동작)
-    3. raw DataFrame 을 DB 스키마(5컬럼)로 정규화 → xlsx 저장
+    3. raw DataFrame 을 Ticker 도메인 객체 리스트로 정규화
     4. (tempfile 자동 정리)
 
 거래소별로 달라지는 부분만 자식이 정의:
     - url(), slug, expected_raw_columns(), normalize_to_schema(raw)
     - _extract_to_dataframe(archive, work_dir): KR=고정폭, 해외=탭구분
+
+산출물 저장과 DB 적재는 별도 어댑터 책임이다 (이 모듈에서 분리됨).
 """
 
 from __future__ import annotations
@@ -23,7 +25,7 @@ import pandas as pd
 import requests
 
 from src.core.interfaces import ILogger
-from src.core.schema import COLUMNS
+from src.core.schema import Ticker
 
 DWS_BASE_URL = "https://new.real.download.dws.co.kr/common/master"
 
@@ -31,10 +33,7 @@ DWS_BASE_URL = "https://new.real.download.dws.co.kr/common/master"
 class MasterDownloader(ABC):
     """run() 이 템플릿. 자식은 추상 메서드만 채운다."""
 
-    SCHEMA_COLUMNS: tuple[str, ...] = COLUMNS
-
-    def __init__(self, data_dir: Path, logger: ILogger) -> None:
-        self.data_dir = data_dir
+    def __init__(self, logger: ILogger) -> None:
         self.logger = logger
 
     # 자식이 정의 (거래소 정체성)
@@ -49,22 +48,22 @@ class MasterDownloader(ABC):
     def expected_raw_columns(self) -> list[str]: ...
 
     @abstractmethod
-    def normalize_to_schema(self, raw: pd.DataFrame) -> pd.DataFrame: ...
+    def normalize_to_schema(self, raw: pd.DataFrame) -> list[Ticker]: ...
 
     # 중간 추상(KR vs 해외)이 정의
     @abstractmethod
     def _extract_to_dataframe(self, archive: Path, work_dir: Path) -> pd.DataFrame: ...
 
     # 템플릿 메서드 — 자식이 override 하지 않음
-    def run(self) -> Path:
-        self.data_dir.mkdir(parents=True, exist_ok=True)
+    def run(self) -> list[Ticker]:
         with tempfile.TemporaryDirectory() as tmp:
             work_dir = Path(tmp)
             archive = self._download(self.url(), work_dir)
             raw = self._extract_to_dataframe(archive, work_dir)
             self._validate_columns(raw)
-            normalized = self.normalize_to_schema(raw)
-        return self._save_xlsx(normalized)
+            tickers = self.normalize_to_schema(raw)
+        self.logger.info(f"[normalize] {self.slug} ({len(tickers)} rows)")
+        return tickers
 
     # 공통 구현
     def _download(self, url: str, work_dir: Path) -> Path:
@@ -98,11 +97,3 @@ class MasterDownloader(ABC):
             raise ValueError(
                 f"[{self.slug}] raw 마스터 컬럼 불일치: missing={sorted(missing)}"
             )
-
-    def _save_xlsx(self, df: pd.DataFrame) -> Path:
-        # SCHEMA_COLUMNS 순서를 강제해 적재 단계와 일치시킨다.
-        df = df[list(self.SCHEMA_COLUMNS)]
-        xlsx_path = self.data_dir / f"{self.slug}_code.xlsx"
-        df.to_excel(xlsx_path, index=False)
-        self.logger.info(f"[excel] {xlsx_path} ({len(df)} rows)")
-        return xlsx_path

--- a/src/core/logic/kosdaq_code.py
+++ b/src/core/logic/kosdaq_code.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pandas as pd
 
 from src.core.logic.kr_master import KrMasterDownloader
+from src.core.schema import Ticker
 
 KOSDAQ_BYTE_SIZE = 222
 
@@ -68,16 +69,21 @@ class KosdaqDownloader(KrMasterDownloader):
     @property
     def part2_columns(self) -> list[str]: return KOSDAQ_PART2_COLUMNS
 
-    def normalize_to_schema(self, raw: pd.DataFrame) -> pd.DataFrame:
+    def normalize_to_schema(self, raw: pd.DataFrame) -> list[Ticker]:
         df = raw.dropna(subset=["단축코드", "증권그룹구분코드"])
         df = df[df["증권그룹구분코드"].isin(KOSDAQ_ASSET_TYPE_MAP)]
         df = df[df["단축코드"].str.len() == 6]
-        return pd.DataFrame(
-            {
-                "ticker": df["단축코드"].values,
-                "exchange": "KQ",
-                "alias": df["한글종목명"].values,
-                "asset_type": df["증권그룹구분코드"].map(KOSDAQ_ASSET_TYPE_MAP).values,
-                "currency": "KRW",
-            }
-        )
+        return [
+            Ticker(
+                ticker=ticker,
+                exchange="KQ",
+                alias=(alias if pd.notna(alias) else None),
+                asset_type=KOSDAQ_ASSET_TYPE_MAP[group],
+                currency="KRW",
+            )
+            for ticker, alias, group in zip(
+                df["단축코드"].values,
+                df["한글종목명"].values,
+                df["증권그룹구분코드"].values,
+            )
+        ]

--- a/src/core/logic/kospi_code.py
+++ b/src/core/logic/kospi_code.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pandas as pd
 
 from src.core.logic.kr_master import KrMasterDownloader
+from src.core.schema import Ticker
 
 KOSPI_BYTE_SIZE = 228
 
@@ -67,16 +68,21 @@ class KospiDownloader(KrMasterDownloader):
     @property
     def part2_columns(self) -> list[str]: return KOSPI_PART2_COLUMNS
 
-    def normalize_to_schema(self, raw: pd.DataFrame) -> pd.DataFrame:
+    def normalize_to_schema(self, raw: pd.DataFrame) -> list[Ticker]:
         df = raw.dropna(subset=["단축코드", "그룹코드"])
         df = df[df["그룹코드"].isin(KOSPI_ASSET_TYPE_MAP)]
         df = df[df["단축코드"].str.len() == 6]
-        return pd.DataFrame(
-            {
-                "ticker": df["단축코드"].values,
-                "exchange": "KS",
-                "alias": df["한글명"].values,
-                "asset_type": df["그룹코드"].map(KOSPI_ASSET_TYPE_MAP).values,
-                "currency": "KRW",
-            }
-        )
+        return [
+            Ticker(
+                ticker=ticker,
+                exchange="KS",
+                alias=(alias if pd.notna(alias) else None),
+                asset_type=KOSPI_ASSET_TYPE_MAP[group],
+                currency="KRW",
+            )
+            for ticker, alias, group in zip(
+                df["단축코드"].values,
+                df["한글명"].values,
+                df["그룹코드"].values,
+            )
+        ]

--- a/src/core/logic/overseas_master.py
+++ b/src/core/logic/overseas_master.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pandas as pd
 
 from src.core.logic.base import DWS_BASE_URL, MasterDownloader
+from src.core.schema import Ticker
 
 OVERSEAS_RAW_COLUMNS: list[str] = [
     "National code", "Exchange id", "Exchange code", "Exchange name",
@@ -43,15 +44,21 @@ class OverseasMasterDownloader(MasterDownloader):
         cod_path = self._extract_zip(archive, work_dir, suffix=".cod")
         return pd.read_table(cod_path, sep="\t", encoding="cp949")
 
-    def normalize_to_schema(self, raw: pd.DataFrame) -> pd.DataFrame:
+    def normalize_to_schema(self, raw: pd.DataFrame) -> list[Ticker]:
         df = raw.dropna(subset=["Symbol", SECTYPE_COL, "Exchange code", "currency"])
         df = df[df[SECTYPE_COL].isin(OVERSEAS_ASSET_TYPE_MAP)]
-        return pd.DataFrame(
-            {
-                "ticker": df["Symbol"].values,
-                "exchange": df["Exchange code"].values,
-                "alias": df["Symbol"].values,
-                "asset_type": df[SECTYPE_COL].map(OVERSEAS_ASSET_TYPE_MAP).values,
-                "currency": df["currency"].values,
-            }
-        )
+        return [
+            Ticker(
+                ticker=symbol,
+                exchange=exchange,
+                alias=symbol,
+                asset_type=OVERSEAS_ASSET_TYPE_MAP[sectype],
+                currency=currency,
+            )
+            for symbol, exchange, sectype, currency in zip(
+                df["Symbol"].values,
+                df["Exchange code"].values,
+                df[SECTYPE_COL].values,
+                df["currency"].values,
+            )
+        ]

--- a/src/infra/sqlite_repository.py
+++ b/src/infra/sqlite_repository.py
@@ -1,24 +1,24 @@
 """tickers.db SQLite CRUD 캡슐화.
 
-엑셀이 이미 DB 스키마(ticker, exchange, alias, asset_type, currency)와 동일한
-형태로 정규화되어 있다고 전제한다. 거래소별 변환 로직은 다운로더에 있으므로
+다운로더가 정규화한 :class:`Ticker` 객체를 그대로 받아 적재한다.
+거래소별 변환 로직은 다운로더에 있고, xlsx 산출물은 별도 어댑터가 담당하므로
 이 모듈은 단순 적재만 책임진다.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import astuple
 from pathlib import Path
-
-import pandas as pd
+from typing import Iterable
 
 from src.core.interfaces import ITickerRepository
 from src.core.schema import (
-    COLUMNS,
     CREATE_TABLE_SQL,
     DROP_TABLE_SQL,
     INSERT_SQL,
     TABLE_NAME,
+    Ticker,
 )
 
 
@@ -36,15 +36,13 @@ class SqliteTickerRepository(ITickerRepository):
             cur.execute(CREATE_TABLE_SQL)
             conn.commit()
 
-    def bulk_insert_from_xlsx_dir(self, data_dir: Path, filenames: list[str]) -> int:
-        frames = [pd.read_excel(data_dir / name) for name in filenames]
-        df = pd.concat(frames, ignore_index=True)
-        df = df[list(COLUMNS)]
+    def insert_many(self, tickers: Iterable[Ticker]) -> int:
+        rows = [astuple(t) for t in tickers]
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.executemany(INSERT_SQL, df.itertuples(index=False, name=None))
+            cur.executemany(INSERT_SQL, rows)
             conn.commit()
-        return len(df)
+        return len(rows)
 
     def group_summary(self) -> list[tuple]:
         with self._connect() as conn:

--- a/src/infra/xlsx_writer.py
+++ b/src/infra/xlsx_writer.py
@@ -1,0 +1,31 @@
+"""Ticker 리스트를 거래소별 xlsx 파일로 저장하는 인프라 어댑터.
+
+워크플로(.github/workflows/update_master_data.yml)가 tickers.db 와 함께 커밋하는
+공식 산출물(data/{slug}_code.xlsx)을 생성한다. 컬럼 순서는 schema.COLUMNS 로 강제.
+"""
+
+from __future__ import annotations
+
+from dataclasses import astuple
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from src.core.interfaces import IArtifactWriter, ILogger
+from src.core.schema import COLUMNS, Ticker
+
+
+class XlsxArtifactWriter(IArtifactWriter):
+    def __init__(self, data_dir: Path, logger: ILogger) -> None:
+        self.data_dir = data_dir
+        self.logger = logger
+
+    def write(self, slug: str, tickers: Iterable[Ticker]) -> Path:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        rows = [astuple(t) for t in tickers]
+        df = pd.DataFrame(rows, columns=list(COLUMNS))
+        xlsx_path = self.data_dir / f"{slug}_code.xlsx"
+        df.to_excel(xlsx_path, index=False)
+        self.logger.info(f"[excel] {xlsx_path} ({len(df)} rows)")
+        return xlsx_path

--- a/src/main.py
+++ b/src/main.py
@@ -39,13 +39,12 @@ class App:
 
     def run(self) -> None:
         try:
-            all_tickers: list[Ticker] = []
+            n = 0
             for d in self.downloaders:
                 tickers = d.run()
                 self.xlsx_writer.write(d.slug, tickers)
-                all_tickers.extend(tickers)
+                n += self.repo.insert_many(tickers)
 
-            n = self.repo.insert_many(all_tickers)
             self.logger.info(f"[insert] inserted: {n}")
 
             self.logger.info("exchange | asset_type | count")

--- a/src/main.py
+++ b/src/main.py
@@ -12,9 +12,11 @@ from src.core.logic.kosdaq_code import KosdaqDownloader
 from src.core.logic.kospi_code import KospiDownloader
 from src.core.logic.nas_code import NasDownloader
 from src.core.logic.nys_code import NysDownloader
+from src.core.schema import Ticker
 from src.infra.logger import ConverterLogger
 from src.infra.notifier import SlackNotifier
 from src.infra.sqlite_repository import SqliteTickerRepository
+from src.infra.xlsx_writer import XlsxArtifactWriter
 
 
 class App:
@@ -24,23 +26,26 @@ class App:
         self.logger = ConverterLogger(log_dir=self.config.LOG_PATH, run_number=run_number)
         self.notifier = SlackNotifier(webhook_url=self.config.SLACK_WEBHOOK_URL, logger=self.logger)
         self.repo = SqliteTickerRepository(self.config.DB_PATH)
+        self.xlsx_writer = XlsxArtifactWriter(self.config.DATA_PATH, self.logger)
         self.downloaders: list[MasterDownloader] = [
-            KospiDownloader(self.config.DATA_PATH, self.logger),
-            KosdaqDownloader(self.config.DATA_PATH, self.logger),
-            NasDownloader(self.config.DATA_PATH, self.logger),
-            NysDownloader(self.config.DATA_PATH, self.logger),
-            AmsDownloader(self.config.DATA_PATH, self.logger),
+            KospiDownloader(self.logger),
+            KosdaqDownloader(self.logger),
+            NasDownloader(self.logger),
+            NysDownloader(self.logger),
+            AmsDownloader(self.logger),
         ]
         # 항상 새 데이터로 만든다.
         self.repo.reset_schema()
 
     def run(self) -> None:
         try:
-            xlsx_paths = [d.run() for d in self.downloaders]
-            n = self.repo.bulk_insert_from_xlsx_dir(
-                self.config.DATA_PATH,
-                [p.name for p in xlsx_paths],
-            )
+            all_tickers: list[Ticker] = []
+            for d in self.downloaders:
+                tickers = d.run()
+                self.xlsx_writer.write(d.slug, tickers)
+                all_tickers.extend(tickers)
+
+            n = self.repo.insert_many(all_tickers)
             self.logger.info(f"[insert] inserted: {n}")
 
             self.logger.info("exchange | asset_type | count")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,11 +1,10 @@
 """각 Downloader 의 normalize_to_schema 동작을 raw fixture 로 검증한다.
 
-리팩토링의 가장 위험도 높은 표면은 거래소별 raw → DB 스키마 매핑이므로,
+리팩토링의 가장 위험도 높은 표면은 거래소별 raw → Ticker 도메인 객체 매핑이므로,
 fixture 로 거래소별 입력/기대출력을 고정해 회귀를 잡는다. 다운로드/압축해제는
 template 메서드의 다른 단계라 별도 테스트.
 """
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -17,7 +16,6 @@ from src.core.logic.kospi_code import KospiDownloader
 from src.core.logic.nas_code import NasDownloader
 from src.core.logic.nys_code import NysDownloader
 from src.core.logic.overseas_master import SECTYPE_COL
-from src.core.schema import COLUMNS
 
 
 @pytest.fixture
@@ -26,7 +24,7 @@ def fake_logger() -> MagicMock:
 
 
 def _make(downloader_cls, fake_logger):
-    return downloader_cls(Path("/tmp"), fake_logger)
+    return downloader_cls(fake_logger)
 
 
 def test_kospi_normalize(fake_logger):
@@ -39,12 +37,12 @@ def test_kospi_normalize(fake_logger):
     )
     out = _make(KospiDownloader, fake_logger).normalize_to_schema(raw)
 
-    assert list(out.columns) == list(COLUMNS)
     # 6자리 + ST/EF 만 통과 (TOOLONG 제외). alias 는 Optional 이라 None 도 유지.
-    assert out["ticker"].tolist() == ["000020", "000040", "999999", "111111"]
-    assert (out["exchange"] == "KS").all()
-    assert (out["currency"] == "KRW").all()
-    assert out["asset_type"].tolist() == ["Stock", "Stock", "ETF", "Stock"]
+    assert [t.ticker for t in out] == ["000020", "000040", "999999", "111111"]
+    assert all(t.exchange == "KS" for t in out)
+    assert all(t.currency == "KRW" for t in out)
+    assert [t.asset_type for t in out] == ["Stock", "Stock", "ETF", "Stock"]
+    assert [t.alias for t in out] == ["동화약품", "KR모터스", "지수상품", None]
 
 
 def test_kosdaq_normalize_uses_kosdaq_specific_columns(fake_logger):
@@ -57,11 +55,11 @@ def test_kosdaq_normalize_uses_kosdaq_specific_columns(fake_logger):
     )
     out = _make(KosdaqDownloader, fake_logger).normalize_to_schema(raw)
 
-    assert list(out.columns) == list(COLUMNS)
-    assert (out["exchange"] == "KQ").all()
-    assert (out["currency"] == "KRW").all()
-    assert out["ticker"].tolist() == ["000020", "000040", "999999"]
-    assert out["asset_type"].tolist() == ["Stock", "Stock", "ETF"]
+    assert all(t.exchange == "KQ" for t in out)
+    assert all(t.currency == "KRW" for t in out)
+    assert [t.ticker for t in out] == ["000020", "000040", "999999"]
+    assert [t.asset_type for t in out] == ["Stock", "Stock", "ETF"]
+    assert [t.alias for t in out] == ["A기업", None, "C기업"]
 
 
 def test_kr_filters_non_st_ef_group_codes(fake_logger):
@@ -73,8 +71,8 @@ def test_kr_filters_non_st_ef_group_codes(fake_logger):
         }
     )
     out = _make(KospiDownloader, fake_logger).normalize_to_schema(raw)
-    assert out["ticker"].tolist() == ["000020", "000050"]
-    assert out["asset_type"].tolist() == ["Stock", "ETF"]
+    assert [t.ticker for t in out] == ["000020", "000050"]
+    assert [t.asset_type for t in out] == ["Stock", "ETF"]
 
 
 @pytest.mark.parametrize("downloader_cls", [NasDownloader, NysDownloader, AmsDownloader])
@@ -89,13 +87,12 @@ def test_overseas_uses_dynamic_exchange_and_currency(downloader_cls, fake_logger
     )
     out = _make(downloader_cls, fake_logger).normalize_to_schema(raw)
 
-    assert list(out.columns) == list(COLUMNS)
-    assert out["ticker"].tolist() == ["AAPL", "QQQ", "MSFT"]
-    assert out["alias"].tolist() == ["AAPL", "QQQ", "MSFT"]
+    assert [t.ticker for t in out] == ["AAPL", "QQQ", "MSFT"]
+    assert [t.alias for t in out] == ["AAPL", "QQQ", "MSFT"]
     # exchange/currency 는 데이터 컬럼에서 가져옴
-    assert (out["exchange"] == "NAS").all()
-    assert (out["currency"] == "USD").all()
-    assert out["asset_type"].tolist() == ["Stock", "ETF", "Stock"]
+    assert all(t.exchange == "NAS" for t in out)
+    assert all(t.currency == "USD" for t in out)
+    assert [t.asset_type for t in out] == ["Stock", "ETF", "Stock"]
 
 
 def test_overseas_drops_rows_with_null_required_fields(fake_logger):
@@ -108,7 +105,7 @@ def test_overseas_drops_rows_with_null_required_fields(fake_logger):
         }
     )
     out = _make(NasDownloader, fake_logger).normalize_to_schema(raw)
-    assert out["ticker"].tolist() == ["AAPL"]
+    assert [t.ticker for t in out] == ["AAPL"]
 
 
 def test_validate_columns_raises_on_missing_expected_columns(fake_logger):


### PR DESCRIPTION
Closes #14

## Summary

`ITickerRepository` 가 인프라 형식(xlsx) 을 시그니처에 노출하던 의존성 역전 위반을 해소한다. 다운로더가 정규화한 결과를 `list[Ticker]` 도메인 객체로 반환하고, xlsx 산출물 생성과 DB 적재를 각각 별개의 어댑터가 담당하도록 책임을 분리했다.

```
Downloader.run() ──► list[Ticker]
                     ├─► XlsxArtifactWriter.write(slug, tickers) → data/{slug}_code.xlsx
                     └─► (모두 합쳐서) TickerRepository.insert_many(tickers) → tickers.db
```

## Changes

- **`core/interfaces.py`**: `ITickerRepository.bulk_insert_from_xlsx_dir` 제거 → `insert_many(Iterable[Ticker])`. `IArtifactWriter` 포트 추가.
- **`core/logic/base.py`**: `MasterDownloader.run()` 반환형 `Path` → `list[Ticker]`. `__init__` 에서 `data_dir` 제거. `_save_xlsx` 와 `SCHEMA_COLUMNS` 삭제.
- **`core/logic/{kospi,kosdaq}_code.py`, `overseas_master.py`**: `normalize_to_schema` 가 `list[Ticker]` 반환. KOSPI/KOSDAQ alias NaN→None 보존.
- **`infra/sqlite_repository.py`**: `insert_many(Iterable[Ticker])` 구현. `dataclasses.astuple` 로 컬럼 순서 자동 보장. **`pandas` import 제거**.
- **`infra/xlsx_writer.py` (신규)**: `XlsxArtifactWriter(IArtifactWriter)` — `data/{slug}_code.xlsx` 생성, `COLUMNS` 순서 강제.
- **`main.py`**: writer 인스턴스 주입, `run()` 흐름 교체 (다운로더 결과를 writer/repo 양쪽에 분배).
- **`tests/test_normalize.py`**: `Ticker` 도메인 객체 기준 assertion. alias=None 보존도 명시 검증.

## Test plan

- [x] `pytest tests/ -v` — 8개 테스트 전부 통과
- [x] `grep -rE "xlsx|to_excel|read_excel" src/core/` — 빈 결과
- [x] `grep -n "import pandas" src/infra/sqlite_repository.py` — 빈 결과
- [ ] `python -m src.main` (네트워크 필요) 후 `data/` 의 5개 xlsx 컬럼 5개·동일 순서 확인
- [ ] `sqlite3 tickers.db "SELECT exchange, asset_type, COUNT(*) FROM tickers GROUP BY 1,2 ORDER BY 1,2;"` 결과를 main 브랜치 결과와 비교

## Out of scope (이슈에 명시)

- `core/schema.py` SQL 상수의 `infra/sqlite_repository.py` 이동
- `App.run()` 오케스트레이션을 `core/use_cases/RebuildTickerDb` 로 추출
- `requests` / `zipfile` 직접 의존을 포트로 추출
- `infra/notifier.py` 의 `logger` 타입 누락 등 미세 정리


---
_Generated by [Claude Code](https://claude.ai/code/session_013xT95v1BS7MStp5FREr6dL)_